### PR TITLE
fix: typo in Apollo version

### DIFF
--- a/ApolloCodegen/Package.swift
+++ b/ApolloCodegen/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(name: "Apollo",
                  url: "https://github.com/apollographql/apollo-ios.git",
                  /// Make sure this version matches the version in your iOS project!
-                 from: "1.0.0-alpha-1"),
+                 from: "1.0.0-alpha.1"),
         
         // The official Swift argument parser.
         .package(url: "https://github.com/apple/swift-argument-parser.git",

--- a/ApolloCodegen/Package.swift
+++ b/ApolloCodegen/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(name: "Apollo",
                  url: "https://github.com/apollographql/apollo-ios.git",
                  /// Make sure this version matches the version in your iOS project!
-                 from: "1.0.0-alpha.1"),
+                 from: "1.0.0-alpha.2"),
         
         // The official Swift argument parser.
         .package(url: "https://github.com/apple/swift-argument-parser.git",


### PR DESCRIPTION
This PR fixes a bug that caused Swift to fail resolving dependencies because no version `1.0.0-alpha-1` of apollo-ios exists.