### PR TITLE
Update generate command to use the targetRootUrl

### DIFF
--- a/ApolloCodegen/Sources/ApolloCodegen/main.swift
+++ b/ApolloCodegen/Sources/ApolloCodegen/main.swift
@@ -99,7 +99,7 @@ struct SwiftScript: ParsableCommand {
       )
 
       // Actually attempt to generate code.
-      try ApolloCodegen.build(with: codegenConfiguration)
+      try ApolloCodegen.build(with: codegenConfiguration, withRootURL: targetRootURL)
     }
   }
 


### PR DESCRIPTION
Not passing the `targetRootUrl` causes the command to match a lot more graphql files than it should (as I described [here](https://github.com/apollographql/apollo-ios/issues/2505)) which is confusing when one already update the `targetRootUrl` var to the proper path.